### PR TITLE
Create standard for getting started with Laravel

### DIFF
--- a/.infrastructure/conf/traefik/dev/traefik-certs.yml
+++ b/.infrastructure/conf/traefik/dev/traefik-certs.yml
@@ -1,0 +1,11 @@
+tls:
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /certificates/local-dev.pem
+        keyFile: /certificates/local-dev-key.pem
+  certificates:
+    - certFile: /certificates/local-dev.pem
+      keyFile: /certificates/local-dev-key.pem
+      stores:
+        - default

--- a/.infrastructure/conf/traefik/dev/traefik-certs.yml
+++ b/.infrastructure/conf/traefik/dev/traefik-certs.yml
@@ -1,11 +1,12 @@
-tls:
-  stores:
-    default:
-      defaultCertificate:
-        certFile: /certificates/local-dev.pem
-        keyFile: /certificates/local-dev-key.pem
-  certificates:
-    - certFile: /certificates/local-dev.pem
-      keyFile: /certificates/local-dev-key.pem
-      stores:
-        - default
+### Uncommment and confiugre if you want to use HTTPS locally
+# tls:
+#   stores:
+#     default:
+#       defaultCertificate:
+#         certFile: /certificates/local-dev.pem
+#         keyFile: /certificates/local-dev-key.pem
+#   certificates:
+#     - certFile: /certificates/local-dev.pem
+#       keyFile: /certificates/local-dev-key.pem
+#       stores:
+#         - default

--- a/.infrastructure/conf/traefik/dev/traefik.yml
+++ b/.infrastructure/conf/traefik/dev/traefik.yml
@@ -1,0 +1,30 @@
+# Allow self-signed certificates
+serversTransport:
+  insecureSkipVerify: true
+
+providers:
+  docker:
+    network: development
+    exposedbydefault: false
+  file:
+      filename: /traefik-certs.yml
+      watch: true
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entrypoint:
+          to: websecure
+          scheme: https
+
+  websecure:
+    address: ":443"
+
+accessLog: {}
+log:
+  level: ERROR
+
+api:
+  dashboard: true
+  insecure: true

--- a/.infrastructure/conf/traefik/dev/traefik.yml
+++ b/.infrastructure/conf/traefik/dev/traefik.yml
@@ -12,11 +12,6 @@ providers:
 entryPoints:
   web:
     address: ":80"
-    http:
-      redirections:
-        entrypoint:
-          to: websecure
-          scheme: https
 
   websecure:
     address: ":443"

--- a/.infrastructure/conf/traefik/prod/traefik.yml
+++ b/.infrastructure/conf/traefik/prod/traefik.yml
@@ -1,0 +1,70 @@
+# Cloudflare TrustedIPs
+x-trustedIps: &trustedIPs
+  - "173.245.48.0/20"
+  - "103.21.244.0/22"
+  - "103.22.200.0/22"
+  - "103.31.4.0/22"
+  - "141.101.64.0/18"
+  - "108.162.192.0/18"
+  - "190.93.240.0/20"
+  - "188.114.96.0/20"
+  - "197.234.240.0/22"
+  - "198.41.128.0/17"
+  - "162.158.0.0/15"
+  - "104.16.0.0/13"
+  - "104.24.0.0/14"
+  - "172.64.0.0/13"
+  - "131.0.72.0/22"
+  - "2400:cb00::/32"
+  - "2606:4700::/32"
+  - "2803:f800::/32"
+  - "2405:b500::/32"
+  - "2405:8100::/32"
+  - "2a06:98c0::/29"
+  - "2c0f:f248::/32"
+
+# Allow self-signed certificates
+serversTransport:
+  insecureSkipVerify: true
+
+providers:
+  docker:
+    network: web-public
+    exposedbydefault: false
+    swarmMode: true
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entrypoint:
+          to: websecure
+          scheme: https
+    forwardedHeaders:
+      trustedIPs: *trustedIPs
+    proxyProtocol:
+      trustedIPs: *trustedIPs
+
+  websecure:
+    address: ":443"
+    forwardedHeaders:
+      trustedIPs: *trustedIPs
+    proxyProtocol:
+      trustedIPs: *trustedIPs
+
+accessLog: {}
+log:
+  level: ERROR
+
+api:
+  dashboard: true
+  insecure: true
+
+certificatesResolvers:
+  letsencryptresolver:
+    acme:
+      email: "changeme@example.com"
+      storage: "/certificates/acme.json"
+      httpChallenge:
+        entryPoint: web

--- a/.infrastructure/conf/traefik/prod/traefik.yml
+++ b/.infrastructure/conf/traefik/prod/traefik.yml
@@ -36,11 +36,11 @@ providers:
 entryPoints:
   web:
     address: ":80"
-    http:
-      redirections:
-        entrypoint:
-          to: websecure
-          scheme: https
+    # http: ### Uncomment if you want to redirect HTTP to HTTPS
+    #   redirections:
+    #     entrypoint:
+    #       to: websecure
+    #       scheme: https
     forwardedHeaders:
       trustedIPs: *trustedIPs
     proxyProtocol:
@@ -61,10 +61,11 @@ api:
   dashboard: true
   insecure: true
 
-certificatesResolvers:
-  letsencryptresolver:
-    acme:
-      email: "changeme@example.com"
-      storage: "/certificates/acme.json"
-      httpChallenge:
-        entryPoint: web
+## Uncomment if you want to use Let's Encrypt (be sure to set your email)
+# certificatesResolvers:
+#   letsencryptresolver:
+#     acme:
+#       email: "changeme@example.com"
+#       storage: "/certificates/acme.json"
+#       httpChallenge:
+#         entryPoint: web

--- a/.infrastructure/volume_data/.gitignore
+++ b/.infrastructure/volume_data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM serversideup/php:8.2-fpm-nginx as base
+
+FROM base as deploy
+COPY --chown=9999:9999 . /var/www/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM serversideup/php:8.2-fpm-nginx as base
+FROM serversideup/php:beta-8.2-fpm-nginx as base
 
 FROM base as deploy
 COPY --chown=9999:9999 . /var/www/html

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -29,11 +29,11 @@ services:
       - ci
 
   mailpit:
-      image: axllent/mailpit
-      networks:
-        - ci
-      depends_on:
-        - traefik
+    image: axllent/mailpit
+    networks:
+      - ci
+    depends_on:
+      - traefik
 
 networks:
   ci:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
   mariadb:
     networks:
-      - web-ci
+      - ci
     environment:
         MYSQL_ROOT_PASSWORD: "rootpassword"
         MYSQL_DATABASE: "laravel_testing"
@@ -11,7 +11,7 @@ services:
 
   php:
     networks:
-      - web-ci
+      - ci
     volumes:
       - .:/var/www/html/
     working_dir: /var/www/html/
@@ -26,12 +26,12 @@ services:
       - .:/usr/src/app/
     working_dir: /usr/src/app/
     networks: 
-      - web-ci
+      - ci
 
   mailhog:
     image: mailhog/mailhog
     networks:
-      - web-ci
+      - ci
 
 networks:
-  web-ci:
+  ci:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+services:
+  mariadb:
+    networks:
+      - web-ci
+    environment:
+        MYSQL_ROOT_PASSWORD: "rootpassword"
+        MYSQL_DATABASE: "laravel_testing"
+        MYSQL_USER: "mysqluser"
+        MYSQL_PASSWORD: "mysqlpassword"
+
+  php:
+    networks:
+      - web-ci
+    volumes:
+      - .:/var/www/html/
+    working_dir: /var/www/html/
+    environment:
+      AUTORUN_ENABLED: false
+    depends_on:
+      - mariadb
+
+  node:
+    image: node:18
+    volumes:
+      - .:/usr/src/app/
+    working_dir: /usr/src/app/
+    networks: 
+      - web-ci
+
+  mailhog:
+    image: mailhog/mailhog
+    networks:
+      - web-ci
+
+networks:
+  web-ci:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,10 +4,10 @@ services:
     networks:
       - ci
     environment:
-        MYSQL_ROOT_PASSWORD: "rootpassword"
-        MYSQL_DATABASE: "laravel_testing"
-        MYSQL_USER: "mysqluser"
-        MYSQL_PASSWORD: "mysqlpassword"
+        MARIADB_ROOT_PASSWORD: "rootpassword"
+        MARIADB_DATABASE: "laravel_testing"
+        MARIADB_USER: "mysqluser"
+        MARIADB_PASSWORD: "mysqlpassword"
 
   php:
     networks:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -28,10 +28,12 @@ services:
     networks: 
       - ci
 
-  mailhog:
-    image: mailhog/mailhog
-    networks:
-      - ci
+  mailpit:
+      image: axllent/mailpit
+      networks:
+        - ci
+      depends_on:
+        - traefik
 
 networks:
   ci:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
+      - "8080:8080"
     volumes:
       # Add Docker as a mounted volume, so that Traefik can read the labels of other services
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -20,18 +21,27 @@ services:
       - .:/var/www/html/
     environment:
       SSL_MODE: mixed
+
     networks:
       - development
     depends_on:
       - traefik
       - mariadb
     labels:
+      # Accept traffic for HTTP
       - "traefik.enable=true"
-      - "traefik.http.routers.laravel.rule=HostRegexp(`laravel.dev.test`)"
-      - "traefik.http.routers.laravel.entrypoints=websecure"
-      - "traefik.http.routers.laravel.tls=true"
-      - "traefik.http.services.laravel.loadbalancer.server.port=443"
-      - "traefik.http.services.laravel.loadbalancer.server.scheme=https"
+      - "traefik.http.routers.laravel-http.rule=HostRegexp(`laravel.dev.test`)"
+      - "traefik.http.routers.laravel-http.entrypoints=web"
+      - "traefik.http.routers.laravel-http.service=laravel-http"
+      - "traefik.http.services.laravel-http.loadbalancer.server.port=80"
+      - "traefik.http.services.laravel-http.loadbalancer.server.scheme=http"
+      # Accept traffic for HTTPS
+      - "traefik.http.routers.laravel-https.rule=HostRegexp(`laravel.dev.test`)"
+      - "traefik.http.routers.laravel-https.entrypoints=websecure"
+      - "traefik.http.routers.laravel-https.service=laravel-https"
+      - "traefik.http.routers.laravel-https.tls=true"
+      - "traefik.http.services.laravel-https.loadbalancer.server.port=443"
+      - "traefik.http.services.laravel-https.loadbalancer.server.scheme=https"
   
   node:
     image: node:18
@@ -47,10 +57,10 @@ services:
     volumes:
       - ./.infrastructure/volume_data/mariadb/database_data/:/var/lib/mysql
     environment:
-        MYSQL_ROOT_PASSWORD: "rootpassword"
-        MYSQL_DATABASE: "laravel"
-        MYSQL_USER: "mysqluser"
-        MYSQL_PASSWORD: "mysqlpassword"
+        MARIADB_ROOT_PASSWORD: "rootpassword"
+        MARIADB_DATABASE: "laravel"
+        MARIADB_USER: "mysqluser"
+        MARIADB_PASSWORD: "mysqlpassword"
     ports:
       - "3306:3306"
 
@@ -61,7 +71,7 @@ services:
       labels:
         - "traefik.enable=true"
         - "traefik.http.routers.mailpit.rule=Host(`mailpit.dev.test`)"
-        - "traefik.http.routers.mailpit.entrypoints=websecure"
+        - "traefik.http.routers.mailpit.entrypoints=web,websecure"
         - "traefik.http.routers.mailpit.tls=true"
         - "traefik.http.services.mailpit.loadbalancer.server.port=8025"
         - "traefik.http.services.mailpit.loadbalancer.server.scheme=http"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,72 @@
+version: '3.8'
+services:
+  traefik:
+    networks:
+      development:
+        aliases:
+          - laravel.dev.test
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      # Add Docker as a mounted volume, so that Traefik can read the labels of other services
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./.infrastructure/conf/traefik/dev/traefik.yml:/traefik.yml:ro
+      - ./.infrastructure/conf/traefik/dev/traefik-certs.yml:/traefik-certs.yml
+      - ./.infrastructure/conf/traefik/dev/certificates/:/certificates
+
+  php:
+    volumes:
+      - .:/var/www/html/
+    environment:
+      SSL_MODE: mixed
+    networks:
+      - development
+    depends_on:
+      - traefik
+      - mariadb
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.laravel.rule=HostRegexp(`laravel.dev.test`)"
+      - "traefik.http.routers.laravel.entrypoints=websecure"
+      - "traefik.http.routers.laravel.tls=true"
+      - "traefik.http.services.laravel.loadbalancer.server.port=443"
+      - "traefik.http.services.laravel.loadbalancer.server.scheme=https"
+  
+  node:
+    image: node:18
+    volumes:
+      - .:/usr/src/app/
+    working_dir: /usr/src/app/
+    networks: 
+      - development
+
+  mariadb:
+    networks:
+      - development
+    volumes:
+      - ./.infrastructure/volume_data/mariadb/database_data/:/var/lib/mysql
+    environment:
+        MYSQL_ROOT_PASSWORD: "rootpassword"
+        MYSQL_DATABASE: "laravel"
+        MYSQL_USER: "mysqluser"
+        MYSQL_PASSWORD: "mysqlpassword"
+    ports:
+      - "3306:3306"
+
+  mailpit:
+      image: axllent/mailpit
+      networks:
+        - development
+      labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.mailpit.rule=Host(`mailpit.dev.test`)"
+        - "traefik.http.routers.mailpit.entrypoints=websecure"
+        - "traefik.http.routers.mailpit.tls=true"
+        - "traefik.http.services.mailpit.loadbalancer.server.port=8025"
+        - "traefik.http.services.mailpit.loadbalancer.server.scheme=http"
+      depends_on:
+        - traefik
+
+networks:
+  development:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,25 +44,25 @@ services:
       - database_custom_conf:/etc/mysql/conf.d
       - database_shared:/shared
 
-  ssh:
-    image: serversideup/docker-ssh
-    ports:
-      - target: 2222
-        published: 2222
-        mode: host
-    environment:
-      # Change the keys below to your own keys (see https://github.com/serversideup/docker-ssh)
-      AUTHORIZED_KEYS: >
-        "# Start Keys
-         ssh-ed25519 1234567890abcdefghijklmnoqrstuvwxyz user-a
-         ssh-ed25519 abcdefghijklmnoqrstuvwxyz1234567890 user-b
-         # End Keys"
-      # Be sure to configure the allowed IP addresses too (see https://github.com/serversideup/docker-ssh)
-      ALLOWED_IPS: "AllowUsers *@127.0.0.1"
-    volumes:
-      - tunnel_ssh_host_keys:/etc/ssh/ssh_host_keys
-    networks:
-        - web-public
+  #### Uncomment and change keys and IP addresses below if you want to use an SSH
+  #### tunnel to access the database from your local machine
+  # ssh:
+  #   image: serversideup/docker-ssh
+  #   ports:
+  #     - target: 2222
+  #       published: 2222
+  #       mode: host
+  #   environment:
+  #     AUTHORIZED_KEYS: >
+  #       "# Start Keys
+  #        ssh-ed25519 1234567890abcdefghijklmnoqrstuvwxyz user-a
+  #        ssh-ed25519 abcdefghijklmnoqrstuvwxyz1234567890 user-b
+  #        # End Keys")
+  #     ALLOWED_IPS: "AllowUsers *@127.0.0.1"
+  #   volumes:
+  #     - tunnel_ssh_host_keys:/etc/ssh/ssh_host_keys
+  #   networks:
+  #       - web-public
 
   php:
     image: example.com/myrepo/my-laravel-app:latest

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -82,18 +82,20 @@ services:
         delay: 5s
         order: start-first
       labels:
+        # Accept traffic for HTTP
         - "traefik.enable=true"
-        - "traefik.http.routers.my-laravel-app.rule=${TRAEFIK_HOST_RULE}"
-        - "traefik.http.routers.my-laravel-app.entrypoints=websecure"
-        - "traefik.http.routers.my-laravel-app.tls=true"
-        - "traefik.http.routers.my-laravel-app.tls.certresolver=letsencryptresolver"
-        - "traefik.http.services.my-laravel-app.loadbalancer.server.port=443"
-        - "traefik.http.services.my-laravel-app.loadbalancer.server.scheme=https"
-        # Health check
-        - "traefik.http.services.my-laravel-app.loadbalancer.healthcheck.path=/ping"
-        - "traefik.http.services.my-laravel-app.loadbalancer.healthcheck.interval=100ms"
-        - "traefik.http.services.my-laravel-app.loadbalancer.healthcheck.timeout=75ms"
-        - "traefik.http.services.my-laravel-app.loadbalancer.healthcheck.scheme=https"
+        - "traefik.http.routers.my-laravel-app-http.rule=HostRegexp(`laravel.dev.test`)"
+        - "traefik.http.routers.my-laravel-app-http.entrypoints=web"
+        - "traefik.http.routers.my-laravel-app-http.service=my-laravel-app-http"
+        - "traefik.http.services.my-laravel-app-http.loadbalancer.server.port=80"
+        - "traefik.http.services.my-laravel-app-http.loadbalancer.server.scheme=http"
+        # Accept traffic for HTTPS
+        - "traefik.http.routers.my-laravel-app-https.rule=HostRegexp(`laravel.dev.test`)"
+        - "traefik.http.routers.my-laravel-app-https.entrypoints=websecure"
+        - "traefik.http.routers.my-laravel-app-https.service=my-laravel-app-https"
+        - "traefik.http.routers.my-laravel-app-https.tls=true"
+        - "traefik.http.services.my-laravel-app-https.loadbalancer.server.port=443"
+        - "traefik.http.services.my-laravel-app-https.loadbalancer.server.scheme=https"
 
 configs:
   traefik:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,115 @@
+version: '3.8'
+services:
+
+  traefik:
+      networks:
+          - web-public
+      ports:
+        - "80:80"
+        - "443:443"
+      deploy:
+        update_config:
+          parallelism: 1
+          delay: 5s
+          order: stop-first
+        placement:
+          constraints:
+            # Make the traefik service run only on the node with this label
+            # as the node with it has the volume for the certificates
+            - node.role==manager
+      volumes:
+        # Add Docker as a mounted volume, so that Traefik can read the labels of other services
+        - /var/run/docker.sock:/var/run/docker.sock:ro
+        - certificates:/certificates
+      configs:
+        - source: traefik
+          target: /etc/traefik/traefik.yml
+
+  mariadb:
+    networks:
+      - web-public
+    environment:
+        MARIADB_ROOT_PASSWORD: "${DB_ROOT_PASSWORD}"
+        MARIADB_DATABASE: "${DB_NAME}"
+        MARIADB_USER: "${DB_USERNAME}"
+        MARIADB_PASSWORD: "${DB_PASSWORD}"
+    deploy:
+      placement:
+        constraints:
+          # Make the MySQL service run only on the node with this label
+          # as the node with it has the volume for the database
+          - node.role==manager
+    volumes:
+      - database_data:/var/lib/mysql
+      - database_custom_conf:/etc/mysql/conf.d
+      - database_shared:/shared
+
+  ssh:
+    image: serversideup/docker-ssh
+    ports:
+      - target: 2222
+        published: 2222
+        mode: host
+    environment:
+      # Change the keys below to your own keys (see https://github.com/serversideup/docker-ssh)
+      AUTHORIZED_KEYS: >
+        "# Start Keys
+         ssh-ed25519 1234567890abcdefghijklmnoqrstuvwxyz user-a
+         ssh-ed25519 abcdefghijklmnoqrstuvwxyz1234567890 user-b
+         # End Keys"
+      # Be sure to configure the allowed IP addresses too (see https://github.com/serversideup/docker-ssh)
+      ALLOWED_IPS: "AllowUsers *@127.0.0.1"
+    volumes:
+      - tunnel_ssh_host_keys:/etc/ssh/ssh_host_keys
+    networks:
+        - web-public
+
+  php:
+    image: example.com/myrepo/my-laravel-app:latest
+    networks:
+      - web-public
+    volumes:
+      - "storage_private:/var/www/html/storage/app/private/"
+      - "storage_public:/var/www/html/storage/app/public/"
+      - "storage_sessions:/var/www/html/storage/framework/sessions"
+      - "storage_logs:/var/www/html/storage/logs"
+    environment:
+      PHP_POOL_NAME: "my-laravel-app"
+    deploy:
+      replicas: 2
+      update_config:
+        parallelism: 1
+        delay: 5s
+        order: start-first
+      labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.my-laravel-app.rule=${TRAEFIK_HOST_RULE}"
+        - "traefik.http.routers.my-laravel-app.entrypoints=websecure"
+        - "traefik.http.routers.my-laravel-app.tls=true"
+        - "traefik.http.routers.my-laravel-app.tls.certresolver=letsencryptresolver"
+        - "traefik.http.services.my-laravel-app.loadbalancer.server.port=443"
+        - "traefik.http.services.my-laravel-app.loadbalancer.server.scheme=https"
+        # Health check
+        - "traefik.http.services.my-laravel-app.loadbalancer.healthcheck.path=/ping"
+        - "traefik.http.services.my-laravel-app.loadbalancer.healthcheck.interval=100ms"
+        - "traefik.http.services.my-laravel-app.loadbalancer.healthcheck.timeout=75ms"
+        - "traefik.http.services.my-laravel-app.loadbalancer.healthcheck.scheme=https"
+
+configs:
+  traefik:
+    name: "traefik.yml"
+    file: ./.infrastructure/conf/traefik/prod/traefik.yml
+
+volumes:
+  certificates:
+  database_data:
+  database_custom_conf:
+  database_shared:
+  storage_private:
+  storage_public:
+  storage_sessions:
+  storage_logs:
+  tunnel_ssh_host_keys:
+
+networks:
+  web-public:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+
+  traefik:
+    image: traefik:v2.10
+
+  mariadb: 
+    image: mariadb:10.11
+
+  php:
+    build:
+      context: .
+      target: base
+    depends_on:
+      - traefik
+      - mariadb


### PR DESCRIPTION
# Goal of this PR
- Define a standard for getting started with a basic Laravel application

# ToDo
- [ ] Create a standard to store everything in (https://github.com/serversideup/spin/issues/26)
- [ ] Create an easy to run template to copy into development
- [ ] Allow HTTP & HTTPS mixed mode
- [ ] Ensure a simple deployment process is possible (maybe providing resources to GitHub Actions, etc)